### PR TITLE
add initial implementation and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,129 @@
 
 A Pub/Sub API/framework for MuchRails using ActiveJob.
 
+## Setup
+
+### Add an ActiveJob to publish events
+
+In e.g. `app/jobs/pub_sub_publish_job.rb`:
+
+```ruby
+class PubSubPublishJob < ApplicationJob
+  include MuchRailsPubSub::PublishJobBehaviors
+
+  # add any additional desired ActiveJob configurations
+  queue_as :critical
+end
+```
+
+### Add a config file for event subscriptions
+
+Create an empty config file named e.g. `config/pub_sub.rb`. This file will hold the configured event subscriptions.
+
+### Add an initializer
+
+This will configure the PubSubPublishJob and load subscriptions in `config/pub_sub.rb`. In e.g. `config/initializers/pub_sub.rb`:
+
+```ruby
+MuchRailsPubSub.configure do |config|
+  config.publish_job = PubSubPublishJob
+  config.logger = Rails.logger
+end
+
+# `MuchRailsPubSub` needs to load subscriptions after the Rails app has
+# been initialized. This allows initialization callbacks to configure
+# `ActiveJob` before pub/sub job classes are required and evaluated by
+# loading subscriptions.
+Rails.application.config.after_initialize do
+  MuchRailsPubSub.load_subscriptions(Rails.root.join("config/pub_sub.rb"))
+end
+```
+
 ## Usage
 
-TODO: Write code samples and usage instructions here
+### Add an event handler job
+
+In e.g. `app/jobs/events/thing/create_v1_job.rb`:
+
+```ruby
+class Events::Thing::CreatedV1Job < ApplicationJob
+  def perform(params)
+    puts "do something when a Thing is created ..."
+    puts "params: #{params.inspect}"
+  end
+end
+```
+
+### Subscribe the event handler job to an event
+
+In e.g. `config/pub_sub.rb`:
+
+```ruby
+MuchRailsPubSub.subscribe "thing.created.v1",
+                          job: Events::Thing::CreatedV1Job
+```
+
+### Publish the event in your code
+
+E.g.:
+
+```ruby
+MuchRailsPubSub.publish("thing.created.v1", key: "value")
+```
+
+In the Rails logger:
+
+```
+Enqueued PubSubPublishJob (Job ID: fc834ce6-2f2d-4953-bb83-e9a272bf2a08) to Sidekiq(critical) with arguments: {"event_id"=>"5aaa5129-69b5-46fe-bff3-2e60c9749d62", "event_name"=>"thing.created.v1", "event_params"=>{:key=>"value"}}
+2021-06-16T13:14:15.116Z pid=31539 tid=mxn INFO: [MuchRailsPubSub] Published "thing.created.v1":
+  ID: "5aaa5129-69b5-46fe-bff3-2e60c9749d62"
+  PARAMS: {:key=>"value"}
+
+2021-06-16T13:14:15.117Z pid=31902 tid=e62 class=PubSubPublishJob jid=1e73eeee286bebe1f57a0e97 INFO: start
+2021-06-16T13:14:15.126Z pid=31902 tid=e0y class=Events::Thing::CreatedV1Job jid=f22958c1fa80a4aee91b2731 INFO: start
+2021-06-16T13:14:15.127Z pid=31902 tid=e62 class=PubSubPublishJob jid=1e73eeee286bebe1f57a0e97 INFO: [MuchRailsPubSub] Dispatched 1 subscription job(s) for "thing.created.v1" (5aaa5129-69b5-46fe-bff3-2e60c9749d62):
+  - Events::Thing::CreatedV1Job
+2021-06-16T13:14:15.127Z pid=31902 tid=e62 class=PubSubPublishJob jid=1e73eeee286bebe1f57a0e97 elapsed=0.01 INFO: done
+do something when a Thing is created ...
+params: {:key=>"value"}
+2021-06-16T13:14:15.129Z pid=31902 tid=e0y class=Events::Thing::CreatedV1Job jid=f22958c1fa80a4aee91b2731 elapsed=0.002 INFO: done
+```
+
+## Testing
+
+### Event Handler Jobs
+
+These are just ActiveJobs; test them like you would test any other ActiveJob.
+
+### Event publishes
+
+MuchRailsPubSub comes with a `TestPublisher` and `TestingPublishedEvents` classes that produce the same side-effects of publishing an event without _actually_ publishing the event. You can then test for these side-effects, in e.g. unit tests, to verify event publishes are happening as expected.
+
+This example assumes you are using [Assert](https://github.com/redding/assert) as your test framework. However, this can be adapted to whatever framework you use.
+
+In e.g. `test/helper.rb`
+
+```ruby
+require "test/support/fake_logger"
+require "much-rails-pub-sub"
+
+MuchRailsPubSub.setup_test_publishing
+MuchRailsPubSub.config.logger = FakeLogger.new
+
+Assert::Context.teardown do
+  MuchRailsPubSub.published_events.clear
+end
+```
+
+In a test:
+
+```ruby
+MuchRailsPubSub.publish("thing.created.v1", key: "value")
+
+latest_event = MuchRailsPubSub.published_events.last
+assert_that(latest_event.name).equals("thing.created.v1")
+assert_that(latest_event.params).equals(key: "value")
+```
 
 ## Installation
 

--- a/lib/much-rails-pub-sub.rb
+++ b/lib/much-rails-pub-sub.rb
@@ -1,6 +1,158 @@
 # frozen_string_literal: true
 
+require "much-rails"
 require "much-rails-pub-sub/version"
+require "much-rails-pub-sub/active_job_publisher"
+require "much-rails-pub-sub/publish_job_behaviors"
+require "much-rails-pub-sub/subscription"
 
 module MuchRailsPubSub
+  include MuchRails::Config
+
+  add_config
+
+  def self.publish(event_name, **event_params)
+    config
+      .publisher_class
+      .call(event_name, event_params: event_params)
+      .tap do |event|
+        published_events << event
+        config.logger.info(
+          "[MuchRailsPubSub] Published #{event.name.inspect}:\n"\
+          "  ID: #{event.id.inspect}\n"\
+          "  PARAMS: #{event.params.inspect}",
+        )
+      end
+  end
+
+  def self.subscribe(event_name, job:)
+    subscriptions <<
+      MuchRailsPubSub::Subscription.new(
+        event_name,
+        job_class: config.constantize_job(job, type: :subscription),
+      )
+  end
+
+  def self.published_events
+    config.published_events
+  end
+
+  def self.subscriptions
+    config.subscriptions
+  end
+
+  def self.load_subscriptions(subscriptions_file_path)
+    config.constantize_publish_job_class
+    # Use `Kernel.load` so we can stub and test this.
+    Kernel.load(subscriptions_file_path)
+  end
+
+  def self.setup_test_publishing
+    require "much-rails-pub-sub/test_publisher"
+
+    config.published_events =
+      MuchRailsPubSub::Config::TestingPublishedEvents.new
+    config.publisher_class = MuchRailsPubSub::TestPublisher
+  end
+
+  class Config
+    attr_reader :publish_job_class
+    attr_accessor :publish_job, :published_events, :publisher_class, :logger
+
+    def initialize
+      @published_events = DefaultPublishedEvents.new
+      @publisher_class = MuchRailsPubSub::ActiveJobPublisher
+    end
+
+    def constantize_publish_job_class
+      @publish_job_class =
+        constantize_job(publish_job, type: :publish).tap do |job_class|
+          unless publish_job_class?(job_class)
+            raise(
+              TypeError,
+              "Publish job classes must mixin MuchRailsPubSub::PublishJob. "\
+              "The given job class, #{job_class.inspect}, does not.",
+            )
+          end
+        end
+    end
+
+    def constantize_job(value, type:)
+      begin
+        value.to_s.constantize
+      rescue NameError
+        raise TypeError, "Unknown #{type} job class: #{value.inspect}."
+      end
+    end
+
+    def subscriptions
+      @subscriptions ||= Subscriptions.new
+    end
+
+    def publish_job_class?(job_class)
+      !!(job_class < MuchRailsPubSub::PublishJobBehaviors)
+    end
+
+    class PublishedEvents < ::Array
+      def <<(value)
+        super
+
+        value
+      end
+    end
+
+    class DefaultPublishedEvents < PublishedEvents
+      def <<(value)
+        value
+      end
+    end
+
+    TestingPublishedEvents = Class.new(PublishedEvents)
+
+    class Subscriptions
+      def initialize
+        @subscriptions = Hash.new{ |hash, key| hash[key] = ::Set.new }
+      end
+
+      def for_event(event_name)
+        @subscriptions[normalize_event_name(event_name)].to_a
+      end
+
+      def <<(subscription)
+        @subscriptions[normalize_event_name(subscription.event_name)] <<
+          subscription
+      end
+
+      def dispatch(publish_params)
+        event_id = publish_params["event_id"]
+        event_name = publish_params["event_name"]
+        event_params = publish_params["event_params"]
+        subscriptions = for_event(event_name)
+        subscription_log_details =
+          subscriptions
+            .map{ |subscription|
+              "  - #{subscription.job_class.inspect}"
+            }
+            .join("\n")
+
+        subscriptions.each{ |subscription| subscription.call(event_params) }
+
+        logger.info(
+          "[MuchRailsPubSub] Dispatched #{subscriptions.size} subscription "\
+          "job(s) for #{event_name.inspect} (#{event_id}):\n"\
+          "#{subscription_log_details}",
+        )
+      end
+
+      private
+
+      def normalize_event_name(name)
+        name.to_s.downcase
+      end
+
+      def logger
+        MuchRailsPubSub.config.logger
+      end
+    end
+  end
 end

--- a/lib/much-rails-pub-sub/active_job_publisher.rb
+++ b/lib/much-rails-pub-sub/active_job_publisher.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "much-rails-pub-sub/publisher"
+
+class MuchRailsPubSub::ActiveJobPublisher < MuchRailsPubSub::Publisher
+  def on_call
+    @publshed_job_id ||=
+      MuchRailsPubSub.config.publish_job_class.perform_later(publish_params)
+
+    event
+  end
+end

--- a/lib/much-rails-pub-sub/event.rb
+++ b/lib/much-rails-pub-sub/event.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "much-rails-pub-sub"
+
+MuchRailsPubSub::Event =
+  Struct.new(:id, :name, :params) do
+    def initialize(name, params:)
+      super(SecureRandom.uuid, name, params)
+    end
+  end

--- a/lib/much-rails-pub-sub/publish_job_behaviors.rb
+++ b/lib/much-rails-pub-sub/publish_job_behaviors.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "much-rails-pub-sub"
+
+module MuchRailsPubSub::PublishJobBehaviors
+  include MuchRails::Mixin
+
+  mixin_instance_methods do
+    def perform(publish_params)
+      MuchRailsPubSub.subscriptions.dispatch(publish_params)
+    end
+  end
+end

--- a/lib/much-rails-pub-sub/publisher.rb
+++ b/lib/much-rails-pub-sub/publisher.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "much-rails-pub-sub"
+require "much-rails-pub-sub/event"
+
+class MuchRailsPubSub::Publisher
+  include MuchRails::CallMethod
+
+  attr_reader :event
+
+  def initialize(event_name, event_params:)
+    @event = MuchRailsPubSub::Event.new(event_name, params: event_params)
+  end
+
+  def on_call
+    raise NotImplementedError
+  end
+
+  def event_id
+    event.id
+  end
+
+  def event_name
+    event.name
+  end
+
+  def event_params
+    event.params
+  end
+
+  private
+
+  def publish_params
+    {
+      "event_id" => event_id,
+      "event_name" => event_name,
+      "event_params" => event_params,
+    }
+  end
+end

--- a/lib/much-rails-pub-sub/subscription.rb
+++ b/lib/much-rails-pub-sub/subscription.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "much-rails-pub-sub"
+
+class MuchRailsPubSub::Subscription
+  attr_reader :event_name, :job_class
+
+  def initialize(event_name, job_class:)
+    @event_name = event_name
+    @job_class = job_class
+
+    unless job_class.respond_to?(:perform_later)
+      raise(
+        ArgumentError,
+        "Invalid job class #{job_class.inspect}: it does not respond to "\
+        "the :perform_later method.",
+      )
+    end
+  end
+
+  def call(params)
+    job_class.perform_later(params)
+  end
+
+  def hash
+    job_class.hash
+  end
+
+  def eql?(other)
+    job_class.eql?(other.job_class)
+  end
+
+  def ==(other)
+    if other.is_a?(self.class)
+      event_name == other.event_name && job_class == other.job_class
+    else
+      super
+    end
+  end
+end

--- a/lib/much-rails-pub-sub/test_publisher.rb
+++ b/lib/much-rails-pub-sub/test_publisher.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "much-rails-pub-sub/publisher"
+
+class MuchRailsPubSub::TestPublisher < MuchRailsPubSub::Publisher
+  def on_call
+    event
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,3 +7,11 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 require "pry"
 
 require "test/support/factory"
+require "test/support/publish_job"
+require "much-rails-pub-sub"
+
+MuchRailsPubSub.configure do |config|
+  config.publish_job = "PublishJob"
+end
+
+MuchRailsPubSub.load_subscriptions("test/support/pub_sub.rb")

--- a/test/support/application_job.rb
+++ b/test/support/application_job.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class ApplicationJob
+  def self.perform_later(*)
+  end
+end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -4,4 +4,8 @@ require "assert/factory"
 
 module Factory
   extend Assert::Factory
+
+  def self.uuid
+    SecureRandom.uuid
+  end
 end

--- a/test/support/fake_logger.rb
+++ b/test/support/fake_logger.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class FakeLogger
+  UNKNOWN = ::Logger::UNKNOWN # 5
+  WARN = ::Logger::WARN # 2
+  DEBUG = ::Logger::DEBUG # 0
+
+  attr_reader :info_calls, :warning_calls, :error_calls, :debug_calls
+  attr_accessor :level
+
+  def initialize(level: DEBUG)
+    @level = level
+    @info_calls = []
+    @warning_calls = []
+    @error_calls = []
+    @debug_calls = []
+  end
+
+  def info(*args)
+    @info_calls << args
+  end
+
+  def warning(*args)
+    @warning_calls << args
+  end
+
+  def error(*args)
+    @error_calls << args
+  end
+
+  def debug(*args)
+    @debug_calls << args
+  end
+end

--- a/test/support/publish_job.rb
+++ b/test/support/publish_job.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "test/support/application_job"
+require "much-rails-pub-sub"
+
+class PublishJob < ApplicationJob
+  include MuchRailsPubSub::PublishJobBehaviors
+end

--- a/test/unit/active_job_publisher_tests.rb
+++ b/test/unit/active_job_publisher_tests.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "assert"
+require "much-rails-pub-sub/active_job_publisher"
+
+class MuchRailsPubSub::ActiveJobPublisher
+  class UnitTests < Assert::Context
+    desc "MuchRailsPubSub::ActiveJobPublisher"
+    subject{ unit_class }
+
+    setup do
+      Assert.stub(MuchRailsPubSub.config, :publish_job_class) do
+        fake_publish_job_class
+      end
+    end
+
+    let(:unit_class){ MuchRailsPubSub::ActiveJobPublisher }
+
+    let(:event_name){ "something_happened_v1" }
+    let(:event_params){ { some: "thing" } }
+    let(:fake_publish_job_class){ FakeJobClass.new }
+
+    should "be configured as expected" do
+      assert_that(subject < MuchRailsPubSub::Publisher).is_true
+    end
+
+    should "call #perform_later on the configured publish job class" do
+      event = subject.call(event_name, event_params: event_params)
+      assert_that(event).is_a?(MuchRailsPubSub::Event)
+
+      assert_that(fake_publish_job_class.perform_calls.size).equals(1)
+      assert_that(fake_publish_job_class.perform_calls.last.args)
+        .equals([
+          "event_id" => event.id,
+          "event_name" => event.name,
+          "event_params" => event.params,
+        ])
+    end
+  end
+
+  class FakeJobClass
+    attr_reader :perform_calls
+
+    def initialize
+      @perform_calls = []
+    end
+
+    def perform_later(*args)
+      @perform_calls << Assert::StubCall.new(*args)
+    end
+  end
+end

--- a/test/unit/event_tests.rb
+++ b/test/unit/event_tests.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "assert"
+require "much-rails-pub-sub/event"
+
+class MuchRailsPubSub::Event
+  class UnitTests < Assert::Context
+    desc "MuchRailsPubSub::Event"
+    subject{ unit_class }
+
+    let(:unit_class){ MuchRailsPubSub::Event }
+
+    let(:event_id){ Factory.uuid }
+    let(:event_name){ "something_happened_v1" }
+    let(:event_params){ { some: "thing" } }
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject{ unit_class.new(event_name, params: event_params) }
+
+    setup do
+      event_id
+      Assert.stub(SecureRandom, :uuid){ event_id }
+    end
+
+    should have_imeths :id, :name, :params
+
+    should "know its attributes" do
+      assert_that(subject.id).equals(event_id)
+      assert_that(subject.name).equals(event_name)
+      assert_that(subject.params).equals(event_params)
+    end
+  end
+end

--- a/test/unit/much-rails-pub-sub_tests.rb
+++ b/test/unit/much-rails-pub-sub_tests.rb
@@ -1,0 +1,290 @@
+# frozen_string_literal: true
+
+require "assert"
+require "much-rails-pub-sub"
+
+require "test/support/fake_logger"
+require "test/support/application_job"
+
+module MuchRailsPubSub
+  class UnitTests < Assert::Context
+    desc "MuchRailsPubSub"
+    subject{ unit_class }
+
+    let(:unit_class){ MuchRailsPubSub }
+
+    let(:event_name){ "something_happened_v1" }
+    let(:event_params){ { some: "thing" } }
+
+    let(:job_value){ "MuchRailsPubSub::TestPublishJob" }
+    let(:job_class){ TestPublishJob }
+
+    let(:logger1){ FakeLogger.new }
+
+    should have_imeths :config
+    should have_imeths :publish, :subscribe
+    should have_imeths :published_events, :subscriptions
+    should have_imeths :load_subscriptions, :setup_test_publishing
+
+    should "be configured as expected" do
+      assert_that(subject).includes(MuchRails::Config)
+    end
+
+    should "know its attributes" do
+      assert_that(subject.config).is_a?(unit_class::Config)
+    end
+  end
+
+  class PublishMethodTests < UnitTests
+    desc ".publish"
+
+    setup do
+      Assert.stub(unit_class.config, :logger){ logger1 }
+
+      @publisher_calls = []
+      Assert.stub_tap_on_call(
+        unit_class.config.publisher_class,
+        :call,
+      ) do |_, call|
+        @publisher_calls << call
+      end
+
+      Assert.stub(unit_class.config, :published_events){ published_events1 }
+    end
+  end
+
+  class DefaultPublishedEventsPublishTests < PublishMethodTests
+    desc "when using the DefaultPublishedEvents"
+
+    let(:published_events1){ unit_class::Config::DefaultPublishedEvents.new }
+
+    should "call the Publish service without storing the published event" do
+      event = subject.publish(event_name, **event_params)
+      assert_that(event).is_a?(MuchRailsPubSub::Event)
+
+      assert_that(@publisher_calls.size).equals(1)
+      assert_that(@publisher_calls.last.pargs).equals([event_name])
+      assert_that(@publisher_calls.last.kargs)
+        .equals(event_params: event_params)
+      assert_that(subject.published_events).is_empty
+    end
+  end
+
+  class TestingPublishedEventsPublishTests < PublishMethodTests
+    desc "when using the TestingPublishedEvents"
+
+    let(:published_events1){ unit_class::Config::TestingPublishedEvents.new }
+
+    should "call the Publish service and store the published event" do
+      event = subject.publish(event_name, **event_params)
+      assert_that(event).is_a?(MuchRailsPubSub::Event)
+
+      assert_that(@publisher_calls.size).equals(1)
+      assert_that(@publisher_calls.last.pargs).equals([event_name])
+      assert_that(@publisher_calls.last.kargs)
+        .equals(event_params: event_params)
+      assert_that(subject.published_events.last).is(event)
+    end
+  end
+
+  class SubscribeMethodTests < UnitTests
+    desc ".subscribe"
+
+    setup do
+      Assert.stub(unit_class.config, :subscriptions){ subscriptions1 }
+    end
+
+    let(:subscriptions1){ unit_class::Config::Subscriptions.new }
+
+    should "push a subscription on to the configured subscriptions" do
+      subject.subscribe(event_name, job: job_value)
+
+      assert_that(subscriptions1.for_event(event_name).size).equals(1)
+      assert_that(subscriptions1.for_event(event_name).last)
+        .equals(unit_class::Subscription.new(event_name, job_class: job_class))
+    end
+  end
+
+  class LoadSubscriptionsTests < UnitTests
+    desc ".load_subscriptions"
+
+    setup do
+      Assert.stub_on_call(
+        subject.config,
+        :constantize_publish_job_class,
+      ) do |call|
+        @constantize_publish_job_class_call = call
+      end
+      Assert.stub_on_call(Kernel, :load){ |call| @load_call = call }
+    end
+
+    let(:subscriptions_file_path){ Factory.file_path }
+
+    should "constantize the publish job class and "\
+           "load the subscriptions file path" do
+      subject.load_subscriptions(subscriptions_file_path)
+      assert_that(@constantize_publish_job_class_call).is_not_nil
+      assert_that(@load_call.args).equals([subscriptions_file_path])
+    end
+  end
+
+  class ConfigTests < UnitTests
+    desc "Config"
+    subject{ config_class }
+
+    let(:config_class){ unit_class::Config }
+  end
+
+  class ConfigInitTests < ConfigTests
+    desc "when init"
+    subject{ config_class.new }
+
+    let(:type_value){ :some_type_value }
+
+    should have_readers :publish_job_class
+    should have_accessors :publish_job, :published_events, :publisher_class
+    should have_accessors :logger
+
+    should "know how to constantize its publish job class" do
+      subject.publish_job = job_value
+      assert_that(subject.publish_job_class).is_nil
+
+      subject.constantize_publish_job_class
+      assert_that(subject.publish_job_class).equals(job_class)
+    end
+
+    should "complain if it can't constantize the publish job class" do
+      ex =
+        assert_that{ subject.constantize_publish_job_class }.raises(TypeError)
+      assert_that(ex.message)
+        .equals("Unknown publish job class: nil.")
+
+      subject.publish_job = "MuchRailsPubSub::UnknownPublishJob"
+      ex =
+        assert_that{ subject.constantize_publish_job_class }.raises(TypeError)
+      assert_that(ex.message)
+        .equals("Unknown publish job class: #{subject.publish_job.inspect}.")
+
+      subject.publish_job = "MuchRailsPubSub::TestNonPublishJob"
+      ex =
+        assert_that{ subject.constantize_publish_job_class }.raises(TypeError)
+      assert_that(ex.message)
+        .equals(
+          "Publish job classes must mixin MuchRailsPubSub::PublishJob. "\
+          "The given job class, MuchRailsPubSub::TestNonPublishJob, does not.",
+        )
+    end
+
+    should "constantize valid job class values" do
+      assert_that(subject.constantize_job(job_value, type: type_value))
+        .equals(job_class)
+    end
+
+    should "complain when constantizing invalid job class values" do
+      ex =
+        assert_that{
+          subject.constantize_job("SomeUnknownInvalidClass", type: type_value)
+        }.raises(TypeError)
+      assert_that(ex.message).includes("Unknown #{type_value} job class: ")
+    end
+
+    should "know if a given job class is a publish job class or not" do
+      assert_that(subject.publish_job_class?(TestPublishJob)).is_true
+      assert_that(subject.publish_job_class?(TestNonPublishJob)).is_false
+    end
+  end
+
+  class SubscriptionsTests < ConfigTests
+    desc "Subscriptions"
+    subject{ subscriptions_class }
+
+    let(:subscriptions_class){ config_class::Subscriptions }
+  end
+
+  class SubscriptionsInitSetupTests < SubscriptionsTests
+    desc "when init"
+    subject{ subscriptions_class.new }
+
+    setup{ subject << subscription1 }
+
+    let(:fake_job_class){ FakeJobClass.new }
+    let(:publish_params) do
+      {
+        "event_name" => event_name,
+        "event_params" => event_params,
+      }
+    end
+  end
+
+  class SubscriptionsInitTests < SubscriptionsInitSetupTests
+    let(:subscription1) do
+      MuchRailsPubSub::Subscription.new(event_name, job_class: fake_job_class)
+    end
+
+    should have_imeths :for_event, :<<, :dispatch
+
+    should "know which subscriptions are configured for an event name" do
+      assert_that(subject.for_event(event_name).size).equals(1)
+      assert_that(subject.for_event(event_name).last).equals(subscription1)
+    end
+
+    should "not add duplicate subscriptions" do
+      subject << subscription1
+      subject << subscription1
+
+      assert_that(subject.for_event(event_name).size).equals(1)
+    end
+  end
+
+  class DispatchSubscriptionsTests < SubscriptionsInitSetupTests
+    desc "when init and dispacting subscriptions"
+
+    setup do
+      Assert.stub(MuchRailsPubSub.config, :logger){ logger1 }
+    end
+
+    let(:subscription1) do
+      FakeSubscription.new(event_name, job_class: fake_job_class)
+    end
+
+    should "dispatch by calling each subscription for the event name" do
+      subject.dispatch(publish_params)
+
+      subject.for_event(event_name).each do |subscription|
+        assert_that(subscription.calls.size).equals(1)
+        assert_that(subscription.calls.last.args).equals([event_params])
+      end
+    end
+  end
+
+  class FakeSubscription < MuchRailsPubSub::Subscription
+    attr_reader :calls
+    def initialize(*args)
+      super
+      @calls = []
+    end
+
+    def call(*args)
+      @calls << Assert::StubCall.new(*args)
+    end
+  end
+
+  class FakeJobClass
+    attr_reader :perform_calls
+
+    def initialize
+      @perform_calls = []
+    end
+
+    def perform_later(*args)
+      @perform_calls << Assert::StubCall.new(*args)
+    end
+  end
+
+  class TestPublishJob < ApplicationJob
+    include MuchRailsPubSub::PublishJobBehaviors
+  end
+
+  class TestNonPublishJob < ApplicationJob
+  end
+end

--- a/test/unit/publish_job_behaviors_tests.rb
+++ b/test/unit/publish_job_behaviors_tests.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "assert"
+require "much-rails-pub-sub/publish_job_behaviors"
+
+require "test/support/application_job"
+
+module MuchRailsPubSub::PublishJobBehaviors
+  class UnitTests < Assert::Context
+    desc "MuchRailsPubSub::Publish::JobBehaviors"
+    subject{ unit_module }
+
+    let(:unit_module){ MuchRailsPubSub::PublishJobBehaviors }
+
+    let(:event_name){ "something_happened_v1" }
+    let(:event_params){ { some: "thing" } }
+
+    should "be configured as expected" do
+      assert_that(subject).includes(MuchRails::Mixin)
+    end
+  end
+
+  class ReceiverTests < UnitTests
+    desc "receiver"
+    subject{ receiver_class }
+
+    let(:receiver_class) do
+      Class.new(ApplicationJob).tap{ |c| c.include unit_module }
+    end
+  end
+
+  class ReceiverInitTests < ReceiverTests
+    desc "when init"
+    subject{ receiver_class.new }
+
+    setup do
+      @subscriptions_dispatch_calls = []
+      Assert.stub_on_call(MuchRailsPubSub.subscriptions, :dispatch) do |call|
+        @subscriptions_dispatch_calls << call
+      end
+    end
+
+    let(:publish_params) do
+      {
+        "event_name" => event_name,
+        "event_params" => event_params,
+      }
+    end
+
+    should have_imeth :perform
+
+    should "dispatch the subscriptions for the given event name with params" do
+      subject.perform(publish_params)
+
+      assert_that(@subscriptions_dispatch_calls.size).equals(1)
+      assert_that(@subscriptions_dispatch_calls.last.args)
+        .equals([publish_params])
+    end
+  end
+end

--- a/test/unit/publisher_tests.rb
+++ b/test/unit/publisher_tests.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "assert"
+require "much-rails-pub-sub/publisher"
+
+class MuchRailsPubSub::Publisher
+  class UnitTests < Assert::Context
+    desc "MuchRailsPubSub::Publisher"
+    subject{ unit_class }
+
+    let(:unit_class){ MuchRailsPubSub::Publisher }
+
+    let(:event_name){ "something_happened_v1" }
+    let(:event_params){ { some: "thing" } }
+
+    should "be configured as expected" do
+      assert_that(subject).includes(MuchRails::CallMethod)
+    end
+
+    should "not implement its on call method" do
+      assert_that{
+        subject.call(event_name, event_params: event_params)
+      }.raises(NotImplementedError)
+    end
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject{ unit_class.new(event_name, event_params: event_params) }
+
+    should have_readers :event
+    should have_imeths :event_id, :event_name, :event_params
+
+    should "know its attributes" do
+      assert_that(subject.event).is_a?(MuchRailsPubSub::Event)
+      assert_that(subject.event.name).equals(event_name)
+      assert_that(subject.event.params).equals(event_params)
+
+      assert_that(subject.event_id).equals(subject.event.id)
+      assert_that(subject.event_name).equals(subject.event.name)
+      assert_that(subject.event_params).equals(subject.event.params)
+    end
+  end
+end

--- a/test/unit/subscription_tests.rb
+++ b/test/unit/subscription_tests.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "assert"
+require "much-rails-pub-sub/subscription"
+
+class MuchRailsPubSub::Subscription
+  class UnitTests < Assert::Context
+    desc "MuchRailsPubSub::Subscription"
+    subject{ unit_class }
+
+    let(:unit_class){ MuchRailsPubSub::Subscription }
+
+    let(:event_name){ "something_happened_v1" }
+    let(:event_params){ { some: "thing" } }
+
+    should "complain if initialized with an invalid job class" do
+      assert_that{ subject.new(event_name, job_class: Class.new) }
+        .raises(ArgumentError)
+    end
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject{ unit_class.new(event_name, job_class: fake_job_class) }
+
+    let(:fake_job_class){ FakeJobClass.new }
+
+    should have_readers :event_name, :job_class
+
+    should "call #perform_later on the configured subscription job class" do
+      subject.call(event_params)
+
+      assert_that(fake_job_class.perform_calls.size).equals(1)
+      assert_that(fake_job_class.perform_calls.last.args)
+        .equals([event_params])
+    end
+  end
+
+  class FakeJobClass
+    attr_reader :perform_calls
+
+    def initialize
+      @perform_calls = []
+    end
+
+    def perform_later(*args)
+      @perform_calls << Assert::StubCall.new(*args)
+    end
+  end
+end

--- a/test/unit/test_publisher_tests.rb
+++ b/test/unit/test_publisher_tests.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "assert"
+require "much-rails-pub-sub/test_publisher"
+
+class MuchRailsPubSub::TestPublisher
+  class UnitTests < Assert::Context
+    desc "MuchRailsPubSub::TestPublisher"
+    subject{ unit_class }
+
+    setup do
+      Assert.stub(MuchRailsPubSub.config, :publish_job_class) do
+        fake_publish_job_class
+      end
+    end
+
+    let(:unit_class){ MuchRailsPubSub::TestPublisher }
+
+    let(:event_name){ "something_happened_v1" }
+    let(:event_params){ { some: "thing" } }
+    let(:fake_publish_job_class){ FakeJobClass.new }
+
+    should "be configured as expected" do
+      assert_that(subject < MuchRailsPubSub::Publisher).is_true
+    end
+
+    should "doesnn't call #perform_later on the configured publish job class" do
+      event = subject.call(event_name, event_params: event_params)
+      assert_that(event).is_a?(MuchRailsPubSub::Event)
+
+      assert_that(fake_publish_job_class.perform_calls.size).equals(0)
+    end
+  end
+
+  class FakeJobClass
+    attr_reader :perform_calls
+
+    def initialize
+      @perform_calls = []
+    end
+
+    def perform_later(*args)
+      @perform_calls << Assert::StubCall.new(*args)
+    end
+  end
+end


### PR DESCRIPTION
This brings in the initial implementation that is being extracted
from other projects where I have repeated this pattern/API
multiple times.

This version of the pattern has been tweaked to not only work
nicely with MuchRails, but also to be used in the context of an
external gem (with regards to configuration and setup).

# Other Changes

### add first-pass README with setup/usage/testing instructions

This is just a first pass based on experience using this pattern
in other projects.
